### PR TITLE
Add tests for reader

### DIFF
--- a/.github/workflows/plugin_preview.yml
+++ b/.github/workflows/plugin_preview.yml
@@ -4,12 +4,14 @@ name: napari hub Preview Page # we use this name to find your preview page artif
 
 on:
   pull_request:
-    branches:
-      - '**'
+    types: [labeled]
+  workflow_dispatch:
 
 jobs:
   preview-page:
     name: Preview Page Deploy
+
+    if: ${{ github.event.label.name == 'hub-preview' && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'
         run: |
-          git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
+          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
 
       # note: if you need dependencies from conda, considering using

--- a/src/zarpaint/_tests/test_reader.py
+++ b/src/zarpaint/_tests/test_reader.py
@@ -1,0 +1,32 @@
+from zarpaint.reader import zarr_tensorstore
+import zarr
+import numpy as np
+
+def test_reader_pass(tmp_path):
+    new_path = tmp_path / "example.test"
+    test_file = zarr_tensorstore(new_path)
+    assert test_file is None
+
+def test_reader_return_callable(tmp_path):
+    example_zarr_folder = tmp_path / 'example.zarr'
+    z1 = zarr.open_array(example_zarr_folder, mode='w', shape=(10000, 10000), chunks=(1000, 1000), dtype='i4', fill_value=0)
+    res = zarr_tensorstore(example_zarr_folder)
+    assert callable(res)
+    
+def test_reader_returns_valid_function(tmp_path):
+    example_zarr_folder = tmp_path / 'example.zarr'
+    z1 = zarr.open_array(example_zarr_folder, mode='w', shape=(10000, 10000), chunks=(1000, 1000), dtype='i4', fill_value=0)
+
+    #TODO: actually generate random test data (np.random.random or something) as the same shape
+    # z1[:] = my_random_array[:]
+
+    res = zarr_tensorstore(example_zarr_folder)
+
+    z2 = res(example_zarr_folder)
+    
+    print(z1)
+    print(z2)
+    assert z2 is not None 
+
+    assert np.testing.assert_allclose(z1, z2)
+

--- a/src/zarpaint/_tests/test_reader.py
+++ b/src/zarpaint/_tests/test_reader.py
@@ -1,32 +1,40 @@
+from typing import List, Tuple
 from zarpaint.reader import zarr_tensorstore
 import zarr
 import numpy as np
 
 def test_reader_pass(tmp_path):
+    """
+    Test that the reader is able to open a test file
+    """
     new_path = tmp_path / "example.test"
     test_file = zarr_tensorstore(new_path)
     assert test_file is None
 
 def test_reader_return_callable(tmp_path):
+    """
+    Test the the reader returns a valid funciton when opening a file
+    """ 
     example_zarr_folder = tmp_path / 'example.zarr'
     z1 = zarr.open_array(example_zarr_folder, mode='w', shape=(10000, 10000), chunks=(1000, 1000), dtype='i4', fill_value=0)
     res = zarr_tensorstore(example_zarr_folder)
     assert callable(res)
     
-def test_reader_returns_valid_function(tmp_path):
+def test_reader_can_read_and_write_to_file(tmp_path):
+    """
+    Creates a zarr file, writes random data to it, then saves the file. Once saved, the file is then 
+    reopened and the data is compared.
+    """
     example_zarr_folder = tmp_path / 'example.zarr'
-    z1 = zarr.open_array(example_zarr_folder, mode='w', shape=(10000, 10000), chunks=(1000, 1000), dtype='i4', fill_value=0)
+    z1 = zarr.open_array(example_zarr_folder, mode='w', shape=(100, 100), chunks=(100, 100))
+    z1[:] = np.random.rand(100, 100)
 
-    #TODO: actually generate random test data (np.random.random or something) as the same shape
-    # z1[:] = my_random_array[:]
+    reader_func = zarr_tensorstore(example_zarr_folder)
 
-    res = zarr_tensorstore(example_zarr_folder)
+    layers = reader_func(example_zarr_folder)
+    assert isinstance(layers, List)
+    assert len(layers) == 1
 
-    z2 = res(example_zarr_folder)
-    
-    print(z1)
-    print(z2)
-    assert z2 is not None 
-
-    assert np.testing.assert_allclose(z1, z2)
-
+    layer_info = layers[0]
+    assert isinstance(layer_info, Tuple) 
+    np.testing.assert_allclose(np.asarray(layer_info[0]), z1)


### PR DESCRIPTION
Three tests have been added. One tests opening a file, one tests that the reader returns a valid function, and one does a round trip of creating, writing to, saving and reopening a zarr file.
We could do more in-depth testing of the metadata that we are getting/reading, but I will do that via unit tests of the individual functions.