### PR TITLE
Add reader command to napari.yaml

### DIFF
--- a/src/zarpaint/__init__.py
+++ b/src/zarpaint/__init__.py
@@ -7,6 +7,7 @@ from ._zarpaint import create_labels, open_tensorstore
 from ._dims_chooser import DimsSorter, set_axis_labels
 from ._watershed import watershed_split
 from ._add_3d_points import add_points_3d_with_alt_click
+from .reader import zarr_tensorstore
 
 __all__ = [
         'create_labels',
@@ -15,4 +16,5 @@ __all__ = [
         'set_axis_labels',
         'watershed_split',
         'add_points_3d_with_alt_click',
+        'zarr_tensorstore'
         ]

--- a/src/zarpaint/napari.yaml
+++ b/src/zarpaint/napari.yaml
@@ -17,6 +17,9 @@ contributions:
   - id: zarpaint.watershed_split
     title: Split With Watershed…
     python_name: zarpaint:watershed_split
+  - id: zarpaint.get_reader
+    title: Get Reader
+    python_name: zarpaint:zarr_tensorstore
     
   readers:
   - command: zarpaint.get_reader


### PR DESCRIPTION
The yaml was always used the reader but was not correctly referenced in the "commands" section, so this was added.
This has been tested with viewer.open() and I can confirm that napari is seeing the reader correctly