### PR TITLE
Add layer refresh after copying data

### DIFF
--- a/src/zarpaint/_copy_data.py
+++ b/src/zarpaint/_copy_data.py
@@ -1,4 +1,5 @@
 from magicgui import magic_factory
+import numpy as np
 
 
 @magic_factory
@@ -14,4 +15,5 @@ def copy_data(
     ndim_dst = dst_data.ndim
     slice_ = napari_viewer.dims.current_step
     slicing = slice_[:ndim_dst - ndim_src]
-    dst_data[slicing] = src_data
+    dst_data[slicing] = np.uint32(src_data)
+    target_layer.refresh()

--- a/src/zarpaint/_copy_data.py
+++ b/src/zarpaint/_copy_data.py
@@ -14,4 +14,5 @@ def copy_data(
     ndim_dst = dst_data.ndim
     slice_ = napari_viewer.dims.current_step
     slicing = slice_[:ndim_dst - ndim_src]
+    dst_data[slicing] = src_data
     target_layer.refresh()

--- a/src/zarpaint/_copy_data.py
+++ b/src/zarpaint/_copy_data.py
@@ -1,5 +1,4 @@
 from magicgui import magic_factory
-import numpy as np
 
 
 @magic_factory
@@ -15,5 +14,4 @@ def copy_data(
     ndim_dst = dst_data.ndim
     slice_ = napari_viewer.dims.current_step
     slicing = slice_[:ndim_dst - ndim_src]
-    dst_data[slicing] = np.uint32(src_data)
     target_layer.refresh()


### PR DESCRIPTION
After copying the data there was no visual feedback about whether it had succeeded until after toggling visibility to trigger a layer refresh. This now refreshes after the copy operation is complete.