### PR TITLE
Warn at import time if tensorstore is missing

### DIFF
--- a/src/zarpaint/__init__.py
+++ b/src/zarpaint/__init__.py
@@ -1,3 +1,14 @@
+import warnings
+
+try:
+    import tensorstore
+except ImportError:
+    warnings.warn(
+        "\nzarpaint performance is much faster if tensorstore is also installed.\n"
+        "It is recommended to install tensorstore with:\n"
+        "python -m pip install tensorstore\n"
+    )
+
 try:
     from ._version import version as __version__
 except ImportError:


### PR DESCRIPTION
Closes https://github.com/jni/zarpaint/issues/46

This PR adds a warning at import time if the optional tensorstore dependency is missing, since the performance of zarpaint is much faster when tensorstore is available.

Here is the output users see:
```python
In [1]: import zarpaint
/Users/genevieb/Documents/GitHub/zarpaint/src/zarpaint/__init__.py:6: UserWarning:
zarpaint performance is much faster if tensorstore is also installed.
It is recommended to install tensorstore with:
python -m pip install tensorstore

  warnings.warn(

In [2]: 
```