### PR TITLE
Add nap6 menu contributions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,10 @@ classifiers =
     Topic :: Software Development :: Testing
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Operating System :: OS Independent
     License :: OSI Approved :: BSD License
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,15 +27,14 @@ package_dir =
 setup_requires = setuptools_scm
 install_requires =
     magicgui
-    napari>=0.4.11.dev80
-    napari-plugin-engine>=0.1.4
+    napari>=0.4.19
     numpy
     pyyaml
     qtpy
     scipy
-    scikit-image
+    scikit-image>=0.21
     toolz
-    zarr
+    zarr>=2.11,<3
 
 python_requires = >=3.7
 

--- a/src/zarpaint/_tests/test_watershed.py
+++ b/src/zarpaint/_tests/test_watershed.py
@@ -69,7 +69,7 @@ def test_watershed_split_3d_with_blobs(make_napari_viewer):
             blob_size_fraction=0.1,
             n_dim=3,
             volume_fraction=0.1,
-            seed=0
+            rng=0,
             )
     labeled_blobs = ndi.label(blobs)[0]
     viewer = make_napari_viewer()

--- a/src/zarpaint/napari.yaml
+++ b/src/zarpaint/napari.yaml
@@ -1,5 +1,5 @@
 name: zarpaint
-schema_version: 0.1.0
+schema_version: 0.2.0
 contributions:
   commands:
   - id: zarpaint.add_points_3d_with_alt_click
@@ -42,3 +42,16 @@ contributions:
     display_name: Split With Watershed
   - command: zarpaint.copy_data
     display_name: Copy Data
+
+  menus:
+    napari/file/new_layer:
+    - command: zarpaint.create_labels
+    napari/layers/visualize:
+      - command: zarpaint.DimsSorter
+      - command: zarpaint.set_axis_labels
+    napari/layers/annotate:
+    - command: zarpaint.add_points_3d_with_alt_click
+    napari/layers/data:
+    - command: zarpaint.copy_data
+    napari/layers/segment:
+    - command: zarpaint.watershed_split


### PR DESCRIPTION
This PR puts the zarpaint widgets and functions in defined menus in napari>=0.5.0.

See NAP-6 for details:

https://napari.org/dev/naps/6-contributable-menus.html

Result (needs napari/napari#7011):

<img width="631" alt="Screenshot 2024-06-26 at 4 53 01 PM" src="https://github.com/jni/zarpaint/assets/492549/9ce64b57-7664-4141-8a40-7da4ef8ea9ac">
<img width="351" alt="Screenshot 2024-06-26 at 4 53 10 PM" src="https://github.com/jni/zarpaint/assets/492549/fb824723-6e68-4b09-a90f-d4344269ffff">
<img width="446" alt="Screenshot 2024-06-26 at 4 53 15 PM" src="https://github.com/jni/zarpaint/assets/492549/f8d257a1-4730-4abd-bb68-1946d9ae9cca">
<img width="324" alt="Screenshot 2024-06-26 at 4 53 20 PM" src="https://github.com/jni/zarpaint/assets/492549/01ca133f-f3cc-4e88-90d8-26e87187f705">
<img width="409" alt="Screenshot 2024-06-26 at 4 53 29 PM" src="https://github.com/jni/zarpaint/assets/492549/6c140805-9d37-43d3-b87c-bc8d1e77dea0">
